### PR TITLE
resetNameIndex fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -553,7 +553,7 @@ const startCreating = async () => {
           if (layerConfigurations[layerConfigIndex].resetNameIndex) {
             _offset = layerConfigurations.reduce((acc, layer, index) => {
               if (index < layerConfigIndex) {
-                acc += layer.growEditionSizeTo;
+                acc = layer.growEditionSizeTo;
                 return acc;
               }
               return acc;


### PR DESCRIPTION
[Fix] There is a small bug with resetNameIndex functionality that breaks the numbers when it is used after the second layer config set. Changing the "+=" to "=" at the line 556 seems to fix it.