### PR TITLE
Fix property mispelling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -718,7 +718,7 @@ const paintLayers = (canvasContext, renderObjectArray, layerData) => {
       drawElement(renderObject, canvasContext),
       0,
       0,
-      format.weight,
+      format.width,
       format.height
     );
   });


### PR DESCRIPTION
I noticed that this property is misspelled when I was trying to integrate `skia-canvas`. This PR fixes it.