### PR TITLE
rebuildAll not working when multiple DNA items match the --omit parameter

### DIFF
--- a/utils/rebuildAll.js
+++ b/utils/rebuildAll.js
@@ -101,13 +101,15 @@ const regenerate = async (dnaData, options) => {
     if (options.omit) {
       const dnaImages = images.split(DNA_DELIMITER);
       // remove every item whose address index matches the omitIndex
+      let elementsToDelete = [];
       dnaImages.forEach((element, index) => {
         if (element.startsWith(`${options.omit}.`)) {
-          dnaImages.splice(index, 1);
+          elementsToDelete.push(index);
         }
       });
+      const removedDnaImages = dnaImages.filter((el, index) => !elementsToDelete.includes(index));
 
-      images = dnaImages.join(DNA_DELIMITER);
+      images = removedDnaImages.join(DNA_DELIMITER);
     }
 
     let results = constructLayerToDna(images, layers);


### PR DESCRIPTION
In the current version, if you want to remove a layer using `--omit` that has more than one element as in the example below, it will only remove the first.
This is because the `splice` method alters the original and thus the indexes shift.

```
DNA: [
  '0.2:swirl#5.png',
  '1.0.1:backpack-FILL.png',
  '1.0.0:1backpack-lines.png',
  '2.1:faceB#3.png',
  '3.1:floral#30.png',
  '4.0:eyesa#3.png',
  '5.0:Clippingexample_0002_bluehair#50.png',
  '7.1:gold chain#40.png',
  '8.0.13:z50,21#10.png',
  '8.1.14:z51,22#10.png'
]
```

The proposed change tracks the indexes to be removed, then uses a filter to create a new object and create the new DNA