### PR TITLE
fix: avoid duplicate draw

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -337,7 +337,7 @@ const loadLayerImg = async (_layer) => {
   });
 };
 
-const drawElement = (_renderObject, mainCanvas) => {
+const drawElement = (_renderObject) => {
   const layerCanvas = createCanvas(format.width, format.height);
   const layerctx = layerCanvas.getContext("2d");
   layerctx.imageSmoothingEnabled = format.smoothing;
@@ -351,7 +351,6 @@ const drawElement = (_renderObject, mainCanvas) => {
   );
 
   addAttributes(_renderObject);
-  mainCanvas.drawImage(layerCanvas, 0, 0, format.width, format.height);
   return layerCanvas;
 };
 
@@ -732,7 +731,7 @@ const paintLayers = (canvasContext, renderObjectArray, layerData) => {
     canvasContext.globalAlpha = renderObject.layer.opacity;
     canvasContext.globalCompositeOperation = renderObject.layer.blendmode;
     canvasContext.drawImage(
-      drawElement(renderObject, canvasContext),
+      drawElement(renderObject),
       0,
       0,
       format.width,


### PR DESCRIPTION
Draw the renderObject/element only in `paintLayers` and not also as a side effect of `drawElement` itself.