### PR TITLE
Fix for zindex sorting not being respected during rebuildAll

### DIFF
--- a/utils/rebuildAll.js
+++ b/utils/rebuildAll.js
@@ -118,7 +118,17 @@ const regenerate = async (dnaData, options) => {
     // reduce the stacked and nested layer into a single array
     const allImages = results.reduce((images, layer) => {
       return [...images, ...layer.selectedElements];
-    }, []);
+    }, []).sort((a, b) => {
+      let zA = 0;
+      if (a.zindex && a.zindex.length > 0) {
+        zA = parseInt(a.zindex.split('z')[1], 10);
+      }
+      let zB = 0;
+      if (b.zindex && b.zindex.length > 0) {
+        zB = parseInt(b.zindex.split('z')[1], 10);
+      }
+      return zA - zB;
+    });
 
     allImages.forEach((layer) => {
       loadedElements.push(loadLayerImg(layer));


### PR DESCRIPTION
Fix for https://github.com/nftchef/art-engine/issues/236 and https://github.com/nftchef/art-engine/issues/209

Not sure if this is the best place to do it, I'm not an expert in the codebase. But essentially by this point in the code, `allImages` should be sorted by zindex, but it is not. So this patches the array to sort based on the `zindex` property of the image objects. This then draws them in order appropriately.