### PR TITLE
Fix for calculating rarity data with identical sub directory names as the layer

### DIFF
--- a/utils/rarityData.js
+++ b/utils/rarityData.js
@@ -56,7 +56,7 @@ layerConfigurations.forEach((config) => {
         // get the last name in the long string path by splitting, then reversing
         .map(
           (pathname) =>
-            `${layer.name}${pathname.split(`${layer.name}`).reverse()[0]}`
+            `${layer.name}${pathname.split(`layers/${layer.name}`).reverse()[0]}`
         )
         // Then, filter out the folders with a weight, those are 'values' not trait_types
         .filter(


### PR DESCRIPTION
When sub directories contained the same string as the layer name, the `split()` would cause the path manipulation logic to fail. This fix makes the the string split on `layers/${layer.name}` which ensures only the highest level layer folder is split.

To reproduce this issue, imagine the layer is `Eyes` and the subdir is `Eyes_Green`. The folder is `layers/Eyes/Eyes_Green/...`

The `split()` would split on both `Eyes` and `Eyes_Green` causing the folder reading logic to fail.