### PR TITLE
Fixed bug where z ordering was not parsing correctly in the layer name

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -142,10 +142,21 @@ const getElementOptions = (layer, sublayer) => {
   return { blendmode, opacity };
 };
 
+/* Parses the z-layering order 
+  "z2," returns 2  // towards front
+  "2," returns -2  // towards back
+  Otherwise returns null
+*/
 const parseZIndex = (str) => {
   const z = zflag.exec(str);
-  return z ? parseInt(z[0].match(/-?\d+/)[0]) : null;
-};
+  if ( z ) {
+    let zIndex = z[0].indexOf("z")
+    if( zIndex == 0 ) {
+      return parseInt( str.slice(1).match(/-?\d+/)[0] );
+    }
+  }
+
+  return null;
 
 const getElements = (path, layer) => {
   return fs


### PR DESCRIPTION
Specific case Z layer ordering is a key feature with art engine but is currently broken. Users defining a layer such as "z-10,Cozy Jacket" should evaluate that "Cozy Jacket" would move the item to z index `-10` despite its parents structure. The offending method is `parseZIndex` within `src/main.js` which attempts to extract and parse an in value with z# Ex. Although "z10," is valid it is fed into the` parseInt` with z still prepended such as `z10` rather than `10`. 

The function will always evaluate to null. This fix allows for the 3 possible cases below as described in the docs: 

**Case 1: User defines no override for Cozy Jacket which uses default value from config.js layerConfigurations[]**
**Directory Input:**
```
- Clothing
    - Cozy Jacket
```
**Output:** 
   - Name: Cozy Jacket
   - Z Order: NULL (no override. default value used instead)

**Case 2: User defines override for Cozy Jacket at -10** 
**Directory Input:**
```
- Clothing
    - z-10,Cozy Jacket
```
**Output:** 
   - Name: Cozy Jacket
   - Z Order: -10

**Case 3: User defines override for Cozy Jacket at 10**
**Directory Input:**
```
- Clothing
    - z10,Cozy Jacket
```
**Output:** 
   - Name: Cozy Jacket
   - Z Order: 10