### PR TITLE
The creators field is deprecated in the JSON metadata

### DIFF
--- a/utils/metaplex.js
+++ b/utils/metaplex.js
@@ -109,7 +109,7 @@ jsonFiles.forEach((file) => {
         },
       ],
       category: "image",
-      creators: creators,
+      // creators: creators, // The creators field is deprecated in the JSON metadata, it should be set in the config file instead.
       compiler: "HashLips Art Engine - NFTChef fork | qualifieddevs.io",
     },
   };


### PR DESCRIPTION
The creators field is deprecated in the JSON metadata, it should be set in the config file instead.

for the latest version of Candy Machine a small change needed to be made

I commented it out in utils/metaplex.js line 112 with the reason in-line